### PR TITLE
Update dependencies to latest version (ruby 4.x, bridgetown ~> 2.1, prismic.io ~> 2.1)

### DIFF
--- a/bridgetown-prismic.gemspec
+++ b/bridgetown-prismic.gemspec
@@ -15,13 +15,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r!^test/!)
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 4.0"
 
-  spec.add_dependency "bridgetown", ">= 1.2.0", "< 2.0"
-  spec.add_dependency "prismic.io", ">= 1.8"
-  spec.add_dependency "async", ">= 1.30", "< 2.0"
+  spec.add_dependency "bridgetown", "~> 2.1"
+  spec.add_dependency "prismic.io", "~> 1.8"
+  spec.add_dependency "async", "~> 2.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", ">= 13.0"
-  spec.add_development_dependency "rubocop-bridgetown", "~> 0.3"
+  spec.add_development_dependency "rubocop-bridgetown", "~> 0.7"
 end

--- a/lib/bridgetown-prismic/origin.rb
+++ b/lib/bridgetown-prismic/origin.rb
@@ -12,8 +12,8 @@ module BridgetownPrismic
     def self.import_document(document) = new("prismic://#{document.type}/#{document.id}",
                                              document).read
 
-    def initialize(id, prismic_document = nil, site: Bridgetown::Current.site)
-      super(id, site: site)
+    def initialize(id, prismic_document = nil, site: Bridgetown::Current.site, bare_text: false)
+      super(id, site: site, bare_text: bare_text)
       @relative_path = Pathname.new("#{id.delete_prefix("prismic://")}.html")
       @prismic_document = prismic_document # could be nil, so model should load preview instance
     end

--- a/lib/bridgetown/utils/prismic_data.rb
+++ b/lib/bridgetown/utils/prismic_data.rb
@@ -2,7 +2,7 @@
 
 module Bridgetown
   module Utils
-    class PrismicData < RubyFrontMatter
+    class PrismicData < Bridgetown::FrontMatter::RubyFrontMatter
       def with_links = Bridgetown::Current.site.config.prismic_link_resolver
 
       def provide_data(&block)

--- a/test/fixtures/src/_layouts/default.html
+++ b/test/fixtures/src/_layouts/default.html
@@ -2,10 +2,10 @@
 ---
 <html>
   <head>
-    <title>{{ site.metadata.title }}</title>
+    <title><%= site.metadata.title %></title>
   </head>
   <body>
     THIS IS MY LAYOUT
-    {{ content }}
+    <%= yield %>
   </body>
 </html>

--- a/test/test_bridgetown_prismic.rb
+++ b/test/test_bridgetown_prismic.rb
@@ -8,7 +8,8 @@ class TestBridgetownPrismic < Bridgetown::TestCase
       "root_dir"    => root_dir,
       "source"      => source_dir,
       "destination" => dest_dir,
-      "quiet"       => true
+      "quiet"       => true,
+      "config"      => root_dir("bridgetown.config.yml")
     )
     @config.run_initializers! context: :static
     @site = Bridgetown::Site.new(@config)


### PR DESCRIPTION
Upgrade van bridgetown-prismic naar Bridgetown 2.1.2, prismic.io 1.8.2 en async 2.x.

### Dependency updates (`bridgetown-prismic.gemspec`)
- **bridgetown**: `">= 1.2.0", "< 2.0"` → `"~> 2.1"`
- **prismic.io**: `">= 1.8"` → `"~> 1.8"`
- **async**: `">= 1.30", "< 2.0"` → `"~> 2.0"`
- **rubocop-bridgetown**: `"~> 0.3"` → `"~> 0.7"`
- **required_ruby_version**: `">= 3.0"` → `">= 4.0"`

### Breaking API-wijzigingen in Bridgetown 2.1

- **`RubyFrontMatter` namespace verplaatst** — `Bridgetown::Utils::RubyFrontMatter` is hernoemd naar `Bridgetown::FrontMatter::RubyFrontMatter`. `PrismicData` overerft nu van de nieuwe locatie.
- **`Origin#initialize` signature gewijzigd** — `Bridgetown::Model::Origin` accepteert nu een `bare_text:` keyword argument. `BridgetownPrismic::Origin#initialize` is aangepast om deze parameter door te geven.

### Test aanpassingen

- **Configuratiebestand pad** — Bridgetown 2.1 zoekt `bridgetown.config.yml` niet meer relatief ten opzichte van `root_dir`. Expliciet `config` pad toegevoegd in de test setup.
- **Standaard template engine is nu ERB** — Test layout omgezet van Liquid (`{{ content }}`) naar ERB (`<%= yield %>`).

### Testplan
- [x] `bundle exec rake test` — 5 tests, 16 assertions, 0 failures, 0 errors


### Todo
Zodra de PR gemerged is kan er een nieuwe versie/release gemaakt worden